### PR TITLE
Fix for Issue #14

### DIFF
--- a/AudioStreamer/AudioStreamer.m
+++ b/AudioStreamer/AudioStreamer.m
@@ -663,7 +663,6 @@ static void ASReadStreamCallBack(CFReadStreamRef aStream, CFStreamEventType even
   [self setState:AS_WAITING_FOR_DATA];
 
   if (!CFReadStreamOpen(stream)) {
-    CFRelease(stream);
     [self failWithErrorCode:AS_FILE_STREAM_OPEN_FAILED];
     return NO;
   }


### PR DESCRIPTION
The CFRelease here causes an `EXC_BAD_ACCESS` as `stream` is accessed later on in `closeReadStream` There's a CFRelease for the stream in `closeReadStream` which will release it at the right time.

This should fix issue #14.
