### PR TITLE
Fixed kCFStreamSSLAllows* deprecation errors

### DIFF
--- a/AudioStreamer/AudioStreamer.m
+++ b/AudioStreamer/AudioStreamer.m
@@ -656,9 +656,6 @@ static void ASReadStreamCallBack(CFReadStreamRef aStream, CFStreamEventType even
   if ([[url absoluteString] rangeOfString:@"https"].location == 0) {
     NSDictionary *sslSettings = @{
       (id)kCFStreamSSLLevel: (NSString*)kCFStreamSocketSecurityLevelNegotiatedSSL,
-      (id)kCFStreamSSLAllowsExpiredCertificates:  @NO,
-      (id)kCFStreamSSLAllowsExpiredRoots:         @NO,
-      (id)kCFStreamSSLAllowsAnyRoot:              @NO,
       (id)kCFStreamSSLValidatesCertificateChain:  @YES,
       (id)kCFStreamSSLPeerName:                   [NSNull null]
     };


### PR DESCRIPTION
In iOS 8 and OS X 10.10 Yosemite SDKs, the `kCFStreamAllows*` constants were deprecated for all projects that were targeting iOS 4+ or OS X 10.6+. These defaulted to `kCFBooleanFalse` (`@NO`) anyway so there's no need to find an alternative.
