### PR TITLE
Small error state fix

### DIFF
--- a/AudioStreamer/AudioStreamer.m
+++ b/AudioStreamer/AudioStreamer.m
@@ -245,14 +245,15 @@ static void ASReadStreamCallBack(CFReadStreamRef aStream, CFStreamEventType even
 }
 
 - (AudioStreamerDoneReason)doneReason {
-  if (errorCode) {
-    return AS_DONE_ERROR;
-  }
   switch (state_) {
     case AS_STOPPED:
       return AS_DONE_STOPPED;
     case AS_DONE:
-      return AS_DONE_EOF;
+      if (errorCode) {
+        return AS_DONE_ERROR;
+      } else {
+        return AS_DONE_EOF;
+      }
     default:
       break;
   }
@@ -478,6 +479,8 @@ static void ASReadStreamCallBack(CFReadStreamRef aStream, CFStreamEventType even
 
   LOG(@"got an error: %@", [AudioStreamer stringForErrorCode:anErrorCode]);
   errorCode = anErrorCode;
+
+  [self setState:AS_DONE];
 
   [self stop];
 }


### PR DESCRIPTION
Made sure state is AS_DONE and doneReason is only AS_DONE_ERROR when the state is AS_DONE.

Currently the state would be AS_STOPPED and the doneReason could have returned AS_DONE_ERROR if an error had occurred in the past.
