### PR TITLE
Added Shoutcast support

### DIFF
--- a/AudioStreamer/AudioStreamer.h
+++ b/AudioStreamer/AudioStreamer.h
@@ -179,6 +179,7 @@ struct queued_packet;
   NSString        *proxyHost;
   int             proxyPort;
   AudioFileTypeID fileType;
+  BOOL            defaultFileTypeUsed;
   UInt32          bufferSize; /* attempted to be guessed, but fallback here */
   UInt32          bufferCnt;
   BOOL            bufferInfinite;


### PR DESCRIPTION
The content type for Shoutcast streams doesn't simply come through in a HTTP header, we need to read the data bytes for it.

MP3 Shoutcast streams did work before, but only because AudioStreamer defaults to MP3 if the content type is not found.
