### PR TITLE
Re-added and fixed AAC support

### DIFF
--- a/AudioStreamer/AudioStreamer.m
+++ b/AudioStreamer/AudioStreamer.m
@@ -1030,8 +1030,7 @@ static void ASReadStreamCallBack(CFReadStreamRef aStream, CFStreamEventType even
       break;
     }
 
-    /* if AAC or SBR needs to be supported, fix this */
-    /*case kAudioFileStreamProperty_FormatList: {
+    case kAudioFileStreamProperty_FormatList: {
       Boolean outWriteable;
       UInt32 formatListSize;
       err = AudioFileStreamGetPropertyInfo(inAudioFileStream,
@@ -1043,20 +1042,25 @@ static void ASReadStreamCallBack(CFReadStreamRef aStream, CFStreamEventType even
       CHECK_ERR(formatList == NULL, AS_FILE_STREAM_GET_PROPERTY_FAILED);
       err = AudioFileStreamGetProperty(inAudioFileStream,
               kAudioFileStreamProperty_FormatList, &formatListSize, formatList);
-      CHECK_ERR(err, AS_FILE_STREAM_GET_PROPERTY_FAILED);
+      if (err) {
+        free(formatList);
+        [self failWithErrorCode:AS_FILE_STREAM_GET_PROPERTY_FAILED];
+        return;
+      }
 
-      for (int i = 0; i * sizeof(AudioFormatListItem) < formatListSize;
+      for (unsigned long i = 0; i * sizeof(AudioFormatListItem) < formatListSize;
            i += sizeof(AudioFormatListItem)) {
         AudioStreamBasicDescription pasbd = formatList[i].mASBD;
 
-        if (pasbd.mFormatID == kAudioFormatMPEG4AAC_HE)
+        if (pasbd.mFormatID == kAudioFormatMPEG4AAC_HE || pasbd.mFormatID == kAudioFormatMPEG4AAC_HE_V2)
         {
+          asbd = pasbd;
           break;
         }
       }
       free(formatList);
       break;
-    }*/
+    }
   }
 }
 


### PR DESCRIPTION
To be honest, I'm not entirely sure why this was commented out. Only one line was needed to fix it and that line exists upstream (mattgallagher/AudioStreamer).

Was it because the iOS simulator used to throw a fit with this and used to require an `#ifdef !TARGET_OS_SIMULATOR`? Or was it the `formatList` memory leak? Either way, they're fixed now and I can't find anything broken with this.
